### PR TITLE
fix docker-compose command typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,35 +22,35 @@ This app demonstrates Rails 7 with PostgreSQL, import maps, turbo, stimulus and 
 ## Initial setup
 ```
 cp .env.example .env
-docker compose build
-docker compose run --rm web bin/rails db:setup
+docker-compose build
+docker-compose run --rm web bin/rails db:setup
 ```
 
 ## Running the Rails app
 ```
-docker compose up
+docker-compose up
 ```
 
 ## Running the Rails console
 When the app is already running with `docker-compose` up, attach to the container:
 ```
-docker compose exec web bin/rails c
+docker-compose exec web bin/rails c
 ```
 
 When no container running yet, start up a new one:
 ```
-docker compose run --rm web bin/rails c
+docker-compose run --rm web bin/rails c
 ```
 
 ## Running tests
 ```
-docker compose run --rm web bundle exec rspec
+docker-compose run --rm web bundle exec rspec
 ```
 
 ## Updating gems
 ```
-docker compose run --rm web bundle update
-docker compose up --build
+docker-compose run --rm web bundle update
+docker-compose up --build
 ```
 
 ## Credits/References


### PR DESCRIPTION
should be "docker-compose" instead "docker compose"